### PR TITLE
fix: hero image broken on PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-02-08
+
+### Fixed
+
+- Hero image broken on PyPI — use absolute GitHub URL instead of relative path
+
 ## [0.1.3] - 2026-02-08
 
 ### Added
@@ -49,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 72 unit tests with full coverage
 - PyPI package distribution via pipx
 
-[Unreleased]: https://github.com/tehnolabs/pixelforge-mcp/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/tehnolabs/pixelforge-mcp/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/tehnolabs/pixelforge-mcp/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/tehnolabs/pixelforge-mcp/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/tehnolabs/pixelforge-mcp/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/tehnolabs/pixelforge-mcp/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # PixelForge MCP
 
 <p align="center">
-  <img src="docs/assets/hero.png" alt="PixelForge MCP" width="600">
+  <img src="https://raw.githubusercontent.com/Tehnolabs/pixelforge-mcp/main/docs/assets/hero.png" alt="PixelForge MCP" width="600">
 </p>
 
 An MCP server for AI-powered image generation, editing, and analysis using Google's Gemini models.

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -31,6 +31,6 @@ storage:
 # Server configuration
 server:
   name: "pixelforge-mcp"
-  version: "0.1.3"
+  version: "0.1.4"
   log_level: "INFO"  # DEBUG, INFO, WARNING, ERROR
   timeout: 120  # CLI command timeout in seconds

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,7 +134,7 @@ storage:
 
 server:
   name: "pixelforge-mcp"
-  version: "0.1.3"
+  version: "0.1.4"
   log_level: "INFO"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixelforge-mcp"
-version = "0.1.3"
+version = "0.1.4"
 description = "AI-powered image generation MCP server with multi-model support"
 authors = [{name = "Ahmed Al-Eryani", email = "ahmed@tehnolabs.com"}]
 readme = "README.md"

--- a/src/pixelforge_mcp/config.py
+++ b/src/pixelforge_mcp/config.py
@@ -52,7 +52,7 @@ class ServerConfig(BaseModel):
     """MCP server configuration."""
 
     name: str = Field("gemini-imagen-mcp", description="Server name")
-    version: str = Field("0.1.3", description="Server version")
+    version: str = Field("0.1.4", description="Server version")
     log_level: str = Field("INFO", description="Logging level")
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -77,7 +77,7 @@ class TestServerConfig:
         """Test ServerConfig uses correct defaults."""
         config = ServerConfig()
         assert config.name == "gemini-imagen-mcp"
-        assert config.version == "0.1.3"
+        assert config.version == "0.1.4"
         assert config.log_level == "INFO"
 
 


### PR DESCRIPTION
## Summary

- Fix broken hero image on PyPI page by switching from relative to absolute GitHub raw URL

## Root cause

PyPI renders the README without access to repo files. The relative path `docs/assets/hero.png` resolves on GitHub but not on PyPI's image proxy.

## Fix

Changed image src to `https://raw.githubusercontent.com/Tehnolabs/pixelforge-mcp/main/docs/assets/hero.png`

## Test plan

- [x] 72 unit tests pass
- [ ] Verify image renders on https://pypi.org/project/pixelforge-mcp/ after publish