### PR TITLE
fix: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -27,7 +27,7 @@ jobs:
       # and processed in JS (not shell), preventing command injection.
       - name: Extract command
         id: extract_command
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           REQUEST: ${{ github.event.comment.body }}
         with:
@@ -43,7 +43,7 @@ jobs:
             }
 
       - name: React with eyes to acknowledge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -76,7 +76,7 @@ jobs:
       pull-requests: write
     steps:
       - name: React with check mark on completion
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -98,7 +98,7 @@ jobs:
       pull-requests: write
     steps:
       - name: React with confused on failure
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.reactions.createForIssueComment({

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run Gemini PR review
         uses: google-github-actions/run-gemini-cli@v0

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:
@@ -33,7 +33,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-dists
           path: dist/
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-dists
           path: dist/


### PR DESCRIPTION
## Summary
- Upgrade `actions/github-script` from v7 to v8 (Node 24)
- Upgrade `actions/checkout` from v4 to v5 (Node 24)
- Upgrade `actions/upload-artifact` from v4 to v5 (Node 24)
- Upgrade `actions/download-artifact` from v4 to v5 (Node 24)

Fixes the CI warning: "Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026."

## Files changed
- `.github/workflows/gemini-dispatch.yml`
- `.github/workflows/gemini-review.yml`
- `.github/workflows/python-publish.yml`

## Test plan
- [ ] Trigger `/gemini-review` on a PR to verify gemini-dispatch + gemini-review workflows
- [ ] Verify no Node.js 20 deprecation warnings in CI output